### PR TITLE
Added support to set default photo group for CTAssetsPicker

### DIFF
--- a/Kite SDK/PSPrintSDK/OLKiteViewController.h
+++ b/Kite SDK/PSPrintSDK/OLKiteViewController.h
@@ -10,12 +10,14 @@
 #import "OLProductTemplate.h"
 
 @class OLPrintOrder;
+@class OLKiteViewController;
+@class ALAssetsGroup;
 
 @protocol OLKiteDelegate <NSObject>
 
 @optional
-- (BOOL)shouldShowAddMorePhotosInReview;
-
+- (BOOL)kiteController:(OLKiteViewController *)controller isDefaultAssetsGroup:(ALAssetsGroup *)group;
+- (BOOL)kiteControllerShouldShowAddMorePhotosInReview:(OLKiteViewController *)controller;
 @end
 
 @interface OLKiteViewController : UIViewController

--- a/Kite SDK/PSPrintSDK/OLOrderReviewViewController.m
+++ b/Kite SDK/PSPrintSDK/OLOrderReviewViewController.m
@@ -235,12 +235,22 @@ static const NSUInteger kTagAlertViewDeletePhoto = 98;
     [self onUserSelectedPhotoCountChange];
 }
 
+- (OLKiteViewController *)kiteViewController {
+    for (UIViewController *vc in self.navigationController.viewControllers) {
+        if ([vc isMemberOfClass:[OLKiteViewController class]]) {
+            return (OLKiteViewController *) vc;
+        }
+    }
+    
+    return nil;
+}
+
 - (BOOL)shouldShowAddMorePhotos{
-    if (![self.delegate respondsToSelector:@selector(shouldShowAddMorePhotosInReview)]){
+    if (![self.delegate respondsToSelector:@selector(kiteControllerShouldShowAddMorePhotosInReview:)]){
         return YES;
     }
     else{
-        return [self.delegate shouldShowAddMorePhotosInReview];
+        return [self.delegate kiteControllerShouldShowAddMorePhotosInReview:[self kiteViewController]];
     }
 }
 
@@ -447,6 +457,14 @@ static const NSUInteger kTagAlertViewDeletePhoto = 98;
 }
 
 #pragma mark - CTAssetsPickerControllerDelegate Methods
+
+- (BOOL)assetsPickerController:(CTAssetsPickerController *)picker isDefaultAssetsGroup:(ALAssetsGroup *)group {
+    if ([self.delegate respondsToSelector:@selector(kiteController:isDefaultAssetsGroup:)]) {
+        return [self.delegate kiteController:[self kiteViewController] isDefaultAssetsGroup:group];
+    }
+    
+    return NO;
+}
 
 - (void)assetsPickerController:(CTAssetsPickerController *)picker didFinishPickingAssets:(NSArray *)assets {
     [self populateArrayWithNewArray:assets dataType:[ALAsset class]];

--- a/Kite SDK/PSPrintSDK/ViewController.m
+++ b/Kite SDK/PSPrintSDK/ViewController.m
@@ -9,6 +9,8 @@
 #import "ViewController.h"
 #import "OLKitePrintSDK.h"
 
+#import <AssetsLibrary/AssetsLibrary.h>
+
 /**********************************************************************
  * Insert your API keys here. These are found under your profile 
  * by logging in to the developer portal at http://kite.ly
@@ -141,7 +143,14 @@ static NSString *const kApplePayMerchantIDKey = @"merchant.co.oceanlabs.kite.ly"
 
 #pragma mark - OLKiteDelete
 
-- (BOOL) shouldShowAddMorePhotosInReview {
+- (BOOL)kiteController:(OLKiteViewController *)controller isDefaultAssetsGroup:(ALAssetsGroup *)group {
+//    if ([[group valueForProperty:ALAssetsGroupPropertyName] isEqualToString:@"Instagram"]) {
+//        return YES;
+//    }
+    return NO;
+}
+
+- (BOOL)kiteControllerShouldShowAddMorePhotosInReview:(OLKiteViewController *)controller {
     return YES;
 }
 


### PR DESCRIPTION
Adds a method to OLKiteDelegate that lets the partner application set a default photo group that the user will be shown when launching the CTAssetPicker.