### PR TITLE
Pass line items to PayPal

### DIFF
--- a/Kite SDK/PSPrintSDK/OLPaymentViewController.m
+++ b/Kite SDK/PSPrintSDK/OLPaymentViewController.m
@@ -590,9 +590,15 @@ UIActionSheetDelegate, UITextFieldDelegate, OLCreditCardCaptureDelegate, UINavig
     [self.printOrder costWithCompletionHandler:^(OLPrintOrderCost *cost, NSError *error) {
         // Create a PayPalPayment
         PayPalPayment *payment = [[PayPalPayment alloc] init];
+        NSMutableArray *accArray = [[NSMutableArray alloc] initWithCapacity:cost.lineItems.count];
+        for (OLPaymentLineItem *item in cost.lineItems){
+            [accArray addObject:[PayPalItem itemWithName:item.description withQuantity:1 withPrice:[item costInCurrency:self.printOrder.currencyCode] withCurrency:self.printOrder.currencyCode withSku:nil]];
+        }
+        payment.items = accArray;
         payment.amount = [cost totalCostInCurrency:self.printOrder.currencyCode];
         payment.currencyCode = self.printOrder.currencyCode;
         payment.shortDescription = self.printOrder.paymentDescription;
+        
         NSAssert(payment.processable, @"oops");
         
         PayPalPaymentViewController *paymentViewController;


### PR DESCRIPTION
While I pass the line items to PayPal, they don't appear anywhere, at least not on the client (they might appear in their account?).
Feel free to delete this pull request and the branch if you feel this is not worth it.