### PR TITLE
Issue#298 recentsAvailable has reversed logic causing all editing con…

### DIFF
--- a/Kite-SDK/PSPrintSDK/OLKiteUtils.m
+++ b/Kite-SDK/PSPrintSDK/OLKiteUtils.m
@@ -91,7 +91,7 @@
 }
 
 + (BOOL)recentsAvailable{
-    return [OLUserSession currentSession].appAssets.count == 0 && [OLUserSession currentSession].recentPhotos.count == 0;
+    return [OLUserSession currentSession].appAssets.count != 0 || [OLUserSession currentSession].recentPhotos.count != 0;
 }
 
 + (NSInteger)numberOfProvidersAvailable{


### PR DESCRIPTION
…trols to hide if disableCameraRoll == true

Changing cameraRollEnabled to false (aka disableCameraRoll in swift) causes button1 of the editingTools to be removedFromSuperView (inexplicably also button2 and button3). It seems the root cause for this is because the code thinks it has no imageProviders. The root cause of this is that recentsAvailable of OLKiteUtils.m has the opposite logic of what it supposed to have. It returns true if no recents are available and false otherwise.

The function should read:
+ (BOOL)recentsAvailable{
return [OLUserSession currentSession].appAssets.count != 0 || [OLUserSession currentSession].recentPhotos.count != 0;
}

Further proof of problem:
If you turn off the camera using
kiteViewController.disableCameraRoll = true
and send no assets to the viewController, button1 will appear but will crash when you tap it.