### PR TITLE
Issue#300 Spurious Maintenance Message

### DIFF
--- a/Kite-SDK/PSPrintSDK/OLKiteViewController.m
+++ b/Kite-SDK/PSPrintSDK/OLKiteViewController.m
@@ -335,7 +335,7 @@ static CGFloat fadeTime = 0.3;
         UIStoryboard *sb = [UIStoryboard storyboardWithName:@"OLKiteStoryboard" bundle:[OLKiteUtils kiteResourcesBundle]];
         UIViewController *vc;
         OLProduct *product;
-        if (groups.count == 0 && !([OLProductTemplate templates].count != 0 && [OLKiteABTesting sharedInstance].launchedWithPrintOrder)) {
+        if (groups.count == 0 && ![OLProductTemplate isSyncInProgress] && !([OLProductTemplate templates].count != 0 && [OLKiteABTesting sharedInstance].launchedWithPrintOrder)) {
                 UIAlertController *ac = [UIAlertController alertControllerWithTitle:NSLocalizedStringFromTableInBundle(@"Store Maintenance", @"KitePrintSDK", [OLKiteUtils kiteLocalizationBundle], @"") message:NSLocalizedStringFromTableInBundle(@"Our store is currently undergoing maintenance so no products are available for purchase at this time. Please try again a little later.", @"KitePrintSDK", [OLKiteUtils kiteLocalizationBundle], @"") preferredStyle:UIAlertControllerStyleAlert];
                 [ac addAction:[UIAlertAction actionWithTitle:NSLocalizedStringFromTableInBundle(@"OK", @"KitePrintSDK", [OLKiteUtils kiteLocalizationBundle], @"Acknowledgent to an alert dialog.") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
                     [welf dismiss];


### PR DESCRIPTION
See description in Issue#300

The problem was that when transitionToNextScreen gets called not all of the product templates have loaded.  When you filter the product groups with groupsWithFilters it can return 0 groups.  This then results in the “Our store is currently undergoing maintenance so no products are available for purchase at this time. Please try again a little later."

This can easily be fixed by checking for [OLProductTemplate isSyncInProgress].  If we are still loading we continue to the products page where we can happily wait for the rest of the products to load.

Perhaps if at the end of loading, no products have been found you can display the maintenance message.